### PR TITLE
update after energy output

### DIFF
--- a/northridge/parameters.par
+++ b/northridge/parameters.par
@@ -59,6 +59,10 @@ RFileName = 'offreceivers.dat'       ! Record Points in extra file
 !xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with
 ! HDF5 support.
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
 &AbortCriteria

--- a/sulawesi/parametersLSW.par
+++ b/sulawesi/parametersLSW.par
@@ -35,9 +35,6 @@ ZRef = -1.0
 refPointMethod = 1
 
 RF_output_on = 0                               ! Rupture front ascii output
-magnitude_output_on =1                         ! Moment magnitude output
-energy_rate_output_on =1                       ! Moment rate output
-energy_rate_printtimeinterval = 30             ! print moment rate every n dt
 OutputPointType = 5                            ! Type (0: no output, 3: ascii file, 4: paraview file, 5: 3+4)
 /
 
@@ -105,6 +102,10 @@ SurfaceOutputInterval = 0.25
 ! xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with
 ! HDF5 support.
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
 &AbortCriteria

--- a/sulawesi/parametersRS.par
+++ b/sulawesi/parametersRS.par
@@ -41,9 +41,6 @@ ZRef = -1.0
 refPointMethod = 1
 
 RF_output_on = 0                               ! Rupture front ascii output
-magnitude_output_on =1                         ! Moment magnitude output
-energy_rate_output_on =1                       ! Moment rate output
-energy_rate_printtimeinterval = 30             ! print moment rate every n dt
 OutputPointType = 5                            ! Type (0: no output, 3: ascii file, 4: paraview file, 5: 3+4)
 /
 
@@ -110,6 +107,10 @@ SurfaceOutputInterval = 0.25
 ! xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with
 ! HDF5 support.
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
 &AbortCriteria

--- a/tpv13/parameters.par
+++ b/tpv13/parameters.par
@@ -31,8 +31,6 @@ ZRef = 0.0
 refPointMethod = 1
 
 RF_output_on = 0                                ! Rupture front ascii output
-magnitude_output_on = 1                         ! Moment magnitude output
-energy_rate_output_on = 0                       ! Moment rate output
 OutputPointType = 4
 /
 
@@ -91,6 +89,10 @@ RFileName = 'tpv12_13_receivers.dat'      ! Record Points in extra file
 ! xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 ! and free-surface output. The HDF5 backend is only supported when SeisSol is compiled with
 ! HDF5 support.
+
+EnergyOutput = 1 ! Computation of energy, written in csv file
+EnergyTerminalOutput = 1 ! Write energy to standard output
+EnergyOutputInterval = 0.5
 /
 
 &AbortCriteria

--- a/tpv13/tpv12_13_fault.yaml
+++ b/tpv13/tpv12_13_fault.yaml
@@ -21,3 +21,8 @@
         mu_d:        0.10
         d_c:         0.50
         cohesion: -200000
+[Tnuc_n, Tnuc_s, Tnuc_d]: !ConstantMap
+    map:
+        Tnuc_n: 0
+        Tnuc_s: 0
+        Tnuc_d: 0


### PR DESCRIPTION
FL2 now needs nucleation stress, therefore added.
Energy_rate and magnitude output are now integrated into new energy output, so remove variables in parameters.par.
Enable energy output.
