### PR TITLE
Update docker actions

### DIFF
--- a/.github/workflows/run-and-deploy-docker.yaml
+++ b/.github/workflows/run-and-deploy-docker.yaml
@@ -19,17 +19,17 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Log into dockerhub
-      uses: docker/login-action@v2.0.0
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD}}
     - name: Extract metadata for Docker
       id: meta
-      uses: docker/metadata-action@v4.0.1
+      uses: docker/metadata-action@v4
       with:
         images: seissol/training
     - name: Build and push Docker image
-      uses: docker/build-push-action@v3.1.1
+      uses: docker/build-push-action@v3
       with:
         context: .
         push: true


### PR DESCRIPTION
If we only require the major version, we don't have to update our dependencies that often, e.g. to fix https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/, which occurred in the docker actions.