### PR TITLE
Specify SCOREC version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,6 +124,7 @@ RUN cd SeisSol/preprocessing/science/rconv \
 
 RUN git clone https://github.com/SCOREC/core.git \
     && cd core \
+    && git checkout tags/v2.2.7 \
     && git submodule update --init \
     && mkdir build && cd build \
     && cmake .. -DCMAKE_INSTALL_PREFIX=/home/tools -DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_BUILD_TYPE=Release -DSCOREC_CXX_FLAGS="-Wno-error=array-bounds" \


### PR DESCRIPTION
This PR adjusts the Dockerfile to explicitly use [v2.2.7](https://github.com/SCOREC/core/releases/tag/v2.2.7) of SCOREC. 
This fixes an error that occurs when trying to build a docker image using the current Dockerfile (at least on my local machine) and should also fix the current Docker Image CI error.