### PR TITLE
Update ipywidgets version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ ipyvtklink==0.2.2
 vtk==9.0.3
 pyvista==0.31.1
 jupyterlab==3.0.16
-ipywidgets==7.6.3
+ipywidgets==8.0.4
 scipy==1.7.1
 pyproj==3.2.1


### PR DESCRIPTION
When including `from ipywidgets import interact` and using that widget, as seen in e.g. the visualization chapter of [tpv13.ipynb](https://github.com/SeisSol/Training/blob/main/tpv13/tpv13.ipynb), we get the following error:

> Failed to load model class 'CheckboxModel' from module '@jupyter-widgets/controls'
>     Error: Module @jupyter-widgets/controls, version ^1.5.0 is not registered, however, 2.0.0 is
> 

This is fixed with a higher ipywidgets version. At first i tried `ipywidgets==7.6.5` , since a similar issue is described [here](https://stackoverflow.com/questions/73715821/jupyter-lab-issue-displaying-widgets-javascript-error).
Ultimately I used the `8.0.4` version to get the widget to run properly, however i didn't test whether the issue is resolved with just `ipywidgets==8.0.0` instead.