### PR TITLE
Switch base container to the SCOPED one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,11 +154,18 @@ RUN apt-get update \
 
 WORKDIR /home
 COPY --from=0 /home/tools tools
-COPY requirements.txt .
 ### need to specify --user for gmsh installation, otherwise the tpv13 notebook can't execute !gmsh
-ENV PROJ_DIR=/home/tools
-RUN python3 -m pip install --upgrade pip && pip3 install -r requirements.txt && pip install --user gmsh && docker-clean
-RUN conda install pyproj==3.2.1 && docker-clean
+RUN conda install \
+    panel \
+    ipyvtklink \
+    vtk \
+    pyvista \
+    ipywidgets \
+    scipy \
+    pyproj \
+    matplotlib \
+    && docker-clean
+RUN python3 -m pip install --upgrade pip && pip install --user gmsh && docker-clean
 ENV PATH=/home/tools/bin:$PATH
 ENV OMP_PLACES="cores"
 ENV OMP_PROC_BIND="spread"

--- a/kaikoura/Kaikoura.ipynb
+++ b/kaikoura/Kaikoura.ipynb
@@ -78,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!OMP_NUM_THREADS=4 SeisSol_Release_dhsw_4_elastic parametersLSW.par"
+    "!OMP_NUM_THREADS=4 mpirun -n 1 SeisSol_Release_dhsw_4_elastic parametersLSW.par"
    ]
   },
   {

--- a/northridge/Northridge.ipynb
+++ b/northridge/Northridge.ipynb
@@ -331,7 +331,7 @@
    "outputs": [],
    "source": [
     "# transform the gmsh mesh into the SeisSol mesh format using pumgen\n",
-    "!pumgen -s msh2 mesh_northridge.msh2"
+    "!mpirun -n 1 pumgen -s msh2 mesh_northridge.msh2"
    ]
   },
   {
@@ -409,7 +409,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!OMP_NUM_THREADS=4 SeisSol_Release_dhsw_4_elastic parameters.par"
+    "!OMP_NUM_THREADS=4 mpirun -n 1 SeisSol_Release_dhsw_4_elastic parameters.par"
    ]
   },
   {
@@ -441,7 +441,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!OMP_NUM_THREADS=4 SeisSol_Release_dhsw_4_viscoelastic2 parameters.par"
+    "!OMP_NUM_THREADS=4 mpirun -n 1 SeisSol_Release_dhsw_4_viscoelastic2 parameters.par"
    ]
   }
  ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-panel==0.13.1
-ipyvtklink==0.2.2 
-vtk==9.2.6
-pyvista==0.31.1
-ipywidgets==8.0.4
-scipy==1.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 panel==0.13.1
 ipyvtklink==0.2.2 
-vtk==9.0.3
+vtk==9.2.6
 pyvista==0.31.1
-jupyterlab==3.0.16
 ipywidgets==8.0.4
-scipy==1.7.1
-pyproj==3.2.1
+scipy==1.7.2

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run -p 53155:53155 alicegabriel/seissol-training
+docker run -p 53155:53155 seissol/seissol-training

--- a/sulawesi/sulawesi.ipynb
+++ b/sulawesi/sulawesi.ipynb
@@ -82,7 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!OMP_NUM_THREADS=4 SeisSol_Release_dhsw_4_elastic parametersLSW.par"
+    "!OMP_NUM_THREADS=4 mpirun -n 1 SeisSol_Release_dhsw_4_elastic parametersLSW.par"
    ]
   },
   {

--- a/tpv13/tpv13.ipynb
+++ b/tpv13/tpv13.ipynb
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pumgen -s msh2 tpv13_training.msh"
+    "!mpirun -n 1 pumgen -s msh2 tpv13_training.msh"
    ]
   },
   {
@@ -131,7 +131,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!OMP_NUM_THREADS=4 SeisSol_Release_dhsw_4_elastic parameters.par"
+    "!OMP_NUM_THREADS=4 mpirun -n 1 SeisSol_Release_dhsw_4_elastic parameters.par"
    ]
   },
   {


### PR DESCRIPTION
I have changed the base container to the SCOPE base container, which has jupyterlab and Intel MPI built in. This version of container should be able to run locally as well as on hpc systems of any mpich variant of MPIs available (at least true for TACC's system).

I have tested a little bit and it seems working fine, but my test is not thorough, so please give it a try using the build available from docker hub [here](https://hub.docker.com/r/wangyinz/seissoltraining), or use the following command.
```
docker pull wangyinz/seissoltraining:test
```

One issue that I discovered while building this is that the Intel MPI does not support Fortran 2008 when using with gfortran. The details are in this issue, https://github.com/SeisSCOPED/container-base/issues/5. However, it seems the fortran binding of HDF5 is not required, so I simply disabled that here.

Also, because the base container has python 3.10, the original fixed version numbers in `requirements.txt` does not work anymore. I switched that to using conda, and it seems doing OK. 