### PR TITLE
Correct numbers in the Sulawesi LSW fault description

### DIFF
--- a/sulawesi/Sulawesi_faultLSW.yaml
+++ b/sulawesi/Sulawesi_faultLSW.yaml
@@ -16,7 +16,7 @@
       r_crit = 4000.0;
       Vs = 3464.0;
       if (r <= r_crit) {
-        return r/(0.7*Vs)+(0.081.0*r_crit/(0.7.0*Vs))*(1.0/(1.0-pow(r/r_crit, 2.0))-1.0);
+        return r/(0.7*Vs)+(0.081*r_crit/(0.7*Vs))*(1.0/(1.0-pow(r/r_crit, 2.0))-1.0);
       }
       return 1000000000.0;
 [s_xx, s_yy, s_zz, s_xy, s_yz, s_xz]: !Include Sulawesi_initial_stressLSW.yaml


### PR DESCRIPTION
There were two numbers of the form `0.081.0` and `0.7.0` respectively. These were apparently correctly parsed by the old ImpalaJIT (for some reason); but the new Impala-to-easi transpiler chokes on them.
Hence, we adjust them to be "proper" floating-point numbers.
